### PR TITLE
fix : 회원가입, 로그인 API의 return type을 ApiResponseDto<SuccessResponse>으로 변경 #34

### DIFF
--- a/src/main/java/com/sparta/netflixclone/controller/MemberController.java
+++ b/src/main/java/com/sparta/netflixclone/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.sparta.netflixclone.common.ApiResponseDto;
 import com.sparta.netflixclone.common.ResponseUtils;
 import com.sparta.netflixclone.common.SuccessResponse;
 import com.sparta.netflixclone.dto.LoginRequestDto;
+import com.sparta.netflixclone.dto.MovieResponseDto;
 import com.sparta.netflixclone.dto.SignupRequestDto;
 import com.sparta.netflixclone.entity.enumclass.ExceptionEnum;
 import com.sparta.netflixclone.exception.CustomException;
@@ -16,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 
@@ -37,7 +39,7 @@ public class MemberController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto signupRequestDto, BindingResult bindingResult) {
+    public ApiResponseDto<SuccessResponse> signup(@Valid @RequestBody SignupRequestDto signupRequestDto, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new CustomException(ExceptionEnum.INVALID_EMAIL_REG);
         }
@@ -45,12 +47,12 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
-        return memberService.login(loginRequestDto);
+    public ApiResponseDto<SuccessResponse> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
+        return memberService.login(loginRequestDto, response);
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponseDto> getMemberByEmail(@RequestParam String email) {
+    public ApiResponseDto<SuccessResponse> getMemberByEmail(@RequestParam String email) {
         // email에 해당하는 멤버 정보를 조회하는 로직 구현
         return memberService.checkEmail(email);
     }

--- a/src/main/java/com/sparta/netflixclone/service/LikeAndWishService.java
+++ b/src/main/java/com/sparta/netflixclone/service/LikeAndWishService.java
@@ -39,7 +39,7 @@ public class LikeAndWishService {
                 return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"LIKE로 변경완료"));
             }
             likesRepository.delete(movieLike.get());
-            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"LIKE DELETE 변경완료"));
+            return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"LIKE DELETE 완료"));
         }
 
         likesRepository.saveAndFlush(Likes.of(id, member, likeRequestDto.getStatus().toString()));
@@ -59,7 +59,7 @@ public class LikeAndWishService {
         if (movieLike.isPresent()) {
             if(movieLike.get().getStatus().equals("LIKE")) {
                 movieLike.get().update(likeRequestDto.getStatus().toString());
-                return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"DISLIKE 변경 완료"));
+                return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"DISLIKE로 변경 완료"));
             }
             likesRepository.delete(movieLike.get());
             return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"DISLIKE DELETE 완료"));

--- a/src/main/java/com/sparta/netflixclone/service/MemberService.java
+++ b/src/main/java/com/sparta/netflixclone/service/MemberService.java
@@ -1,7 +1,10 @@
 package com.sparta.netflixclone.service;
 
 import com.sparta.netflixclone.common.ApiResponseDto;
+import com.sparta.netflixclone.common.ResponseUtils;
+import com.sparta.netflixclone.common.SuccessResponse;
 import com.sparta.netflixclone.dto.LoginRequestDto;
+import com.sparta.netflixclone.dto.MovieResponseDto;
 import com.sparta.netflixclone.dto.SignupRequestDto;
 import com.sparta.netflixclone.entity.Member;
 import com.sparta.netflixclone.exception.CustomException;
@@ -14,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
 
 import static com.sparta.netflixclone.entity.enumclass.ExceptionEnum.*;
@@ -25,7 +29,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
-    public ResponseEntity<ApiResponseDto> signup(SignupRequestDto signupRequestDto) {
+    public ApiResponseDto<SuccessResponse> signup(SignupRequestDto signupRequestDto) {
         String email = signupRequestDto.getEmail();
         String password = passwordEncoder.encode(signupRequestDto.getPassword());
         String nickname = signupRequestDto.getNickname();
@@ -38,11 +42,10 @@ public class MemberService {
 
         Member member = Member.of(email, password, nickname, image);
         memberRepository.save(member);
-        return ResponseEntity.ok()
-                .body(ApiResponseDto.of(true, HttpStatus.CREATED));
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.CREATED,"회원가입 완료"));
     }
 
-    public ResponseEntity<ApiResponseDto> login(LoginRequestDto loginRequestDto) {
+    public ApiResponseDto<SuccessResponse> login(LoginRequestDto loginRequestDto, HttpServletResponse response) {
         String email = loginRequestDto.getEmail();
         String password = loginRequestDto.getPassword();
 
@@ -55,20 +58,17 @@ public class MemberService {
             throw new CustomException(PASSWORD_WRONG);
         }
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(user.get().getEmail()));
+        //HttpHeaders headers = new HttpHeaders();
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(user.get().getEmail()));
 
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(ApiResponseDto.of(true, HttpStatus.OK));
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"회원가입 완료"));
     }
 
-    public ResponseEntity<ApiResponseDto> checkEmail(String email) {
+    public ApiResponseDto<SuccessResponse> checkEmail(String email) {
         Optional<Member> foundUsername = memberRepository.findByEmail(email);
         if (foundUsername.isPresent()) {
             throw new CustomException(DUPLICATE_USER);
         }
-        return ResponseEntity.ok()
-                .body(ApiResponseDto.of(true,HttpStatus.OK));
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK,"사용가능한 이메일입니다."));
     }
 }


### PR DESCRIPTION

fix : 회원가입, 로그인 API의 return type을 ApiResponseDto<SuccessResponse>으로 변경 #34

특이사항 : 좋아요, 싫어요의 return 시 message를 간결하게 바꿨습니다.